### PR TITLE
Update pom.xml to use JNA version 4.2.0

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -134,6 +134,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+      
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>4.2.0</version>
+        </dependency>
 
         <dependency>
             <groupId>info.archinnov</groupId>


### PR DESCRIPTION
Achilles which is a dependency of Zeppelin: Apache Cassandra Interpreter has a dependency on Cassandra 2.2.3. Cassandra 2.2.3 has a dependency on JNA version 4.0.0 which is not compatible with ppc64le. The code changes contain the dependency to use JNA version 4.2.0 in cassandra/pom.xml

Related to #1 