### PR TITLE
Update zeppelin-web pom.xml with node and frontend maven plugin version change

### DIFF
--- a/zeppelin-web/pom.xml
+++ b/zeppelin-web/pom.xml
@@ -89,7 +89,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.25</version>
+        <version>1.1</version>
         <executions>
 
           <execution>
@@ -98,7 +98,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v0.12.13</nodeVersion>
+              <nodeVersion>v4.4.7</nodeVersion>
               <npmVersion>2.15.0</npmVersion>
             </configuration>
           </execution>


### PR DESCRIPTION
The frontend-maven-plugin version should be changed to 1.1 and the node version should be changed to 4.4.7 in the zeppelin-web/pom.xml file.

Resolves #3 