### PR TITLE
Update package.json with phantomjs version

### DIFF
--- a/zeppelin-web/package.json
+++ b/zeppelin-web/package.json
@@ -35,7 +35,8 @@
     "karma-jasmine": "~0.1.5",
     "karma-phantomjs-launcher": "~0.1.4",
     "load-grunt-tasks": "^0.4.0",
-    "time-grunt": "^0.3.1"
+    "time-grunt": "^0.3.1",
+    "phantomjs": "^1.9.8"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
The phantomjs 2.1.1 ,which is installed globally is not detected . To resolve the issue, add Phantomjs version ^1.9.8 in zeppelin-web/package.json .